### PR TITLE
Equinox OSGi support

### DIFF
--- a/container-common/src/main/java/org/jboss/arquillian/container/osgi/AbstractOSGiApplicationArchiveProcessor.java
+++ b/container-common/src/main/java/org/jboss/arquillian/container/osgi/AbstractOSGiApplicationArchiveProcessor.java
@@ -106,7 +106,6 @@ public abstract class AbstractOSGiApplicationArchiveProcessor implements Applica
 
         // Add common test imports
         builder.addImportPackages("org.jboss.arquillian.container.test.api", "org.jboss.arquillian.junit", "org.jboss.arquillian.osgi", "org.jboss.arquillian.test.api");
-        builder.addImportPackages("org.jboss.osgi.testing");
         builder.addImportPackages("org.jboss.shrinkwrap.api", "org.jboss.shrinkwrap.api.asset", "org.jboss.shrinkwrap.api.spec");
         builder.addImportPackages("org.junit", "org.junit.runner", "javax.inject", "org.osgi.framework");
 


### PR DESCRIPTION
It seems that equinox need the have the bundle refreshed after
it is installed so that the package imports can be resolved and
the bundle moved to the resolved state. This allows the classes
to be loaded seen and loaded from the arquillian bundle via it's
DynamicImport-Package constraint.
