### PR TITLE
Add org.junit.runners.model to arquillian-osgi-bundle exports

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -121,6 +121,7 @@
                             org.jboss.shrinkwrap.api.exporter;version=${version.jboss.shrinkwrap},
                             org.jboss.shrinkwrap.api.container;version=${version.jboss.shrinkwrap},
                             org.junit.runner;version=${version.junit},
+                            org.junit.runners.model;version=${version.junit},
                             org.junit;version=${version.junit},
                             org.junit.rules;version=${version.junit},
                         </_exportcontents>


### PR DESCRIPTION
Some libraries like assertj need org.junit.runners.model package to work. Let's add it to exported packages in arquillian-osgi-bundle
