### PR TITLE
Support remote containers on remote hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ Arquillian OSGi Container
 
 The Arquillian OSGi Container provides Arquillian testing in OSGi frameworks.
 
-Maven Setup
+Embedded Container Setup
 -----------
 
-For the [JBOSGi Framework](https://github.com/jbosgi/jbosgi-framework) setup the following dependencies
+For the [JBOSGi Framework](https://github.com/jbosgi/jbosgi-framework) setup the following Maven dependencies:
 
     <dependencies>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-osgi-embedded</artifactId>
+            <artifactId>arquillian-container-jbosgi-embedded</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.osgi.framework</groupId>
@@ -19,12 +19,12 @@ For the [JBOSGi Framework](https://github.com/jbosgi/jbosgi-framework) setup the
         </dependency>
     </dependencies>
     
-for [Apache Felix](http://felix.apache.org/documentation/subprojects/apache-felix-framework.html) setup these
+For [Apache Felix](http://felix.apache.org/documentation/subprojects/apache-felix-framework.html) setup these:
 
     <dependencies>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-osgi-felix</artifactId>
+            <artifactId>arquillian-container-felix-embedded</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
@@ -36,7 +36,37 @@ for [Apache Felix](http://felix.apache.org/documentation/subprojects/apache-feli
         </dependency>
     </dependencies>
     
-The arquillian.xml resource references the framework configuration file
+For [Apache Karaf](http://karaf.apache.org/) setup these:
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-karaf-embedded</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf</groupId>
+            <artifactId>org.apache.karaf.main</artifactId>
+        </dependency>
+    </dependencies>
+    
+For [Eclipse Equinox](http://www.eclipse.org/equinox/) setup these:
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-equinox-embedded</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+        </dependency>
+    </dependencies>
+    
+For each of these embedded containers, create an arquillian.xml resource that references a framework configuration file:
 
 	<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
@@ -48,7 +78,7 @@ The arquillian.xml resource references the framework configuration file
 		</container>
 	</arquillian>
 
-which is in standard properties format 
+The framework configuration file is in standard properties format:
 
 	# Properties to configure the Framework
 	org.osgi.framework.storage=./target/osgi-store
@@ -68,7 +98,91 @@ which is in standard properties format
 		file://${test.archive.directory}/bundles/jboss-osgi-logging.jar,\
 		file://${test.archive.directory}/bundles/jbosgi-repository-bundle.jar,\
 		file://${test.archive.directory}/bundles/jbosgi-provision-bundle.jar
-	
+
+Check the test/resource folders for each of the container implementations for container specific examples.
+
+Remote Container Setup
+---------------------
+
+The Arquillian OSGi Container also supports deployment to remote containers, running on the same host or remote hosts.
+
+To use a remote [Apache Karaf](http://karaf.apache.org/), or any container running an
+OSGi Enterprise JMX implementation such as [Apache Aries JMX](http://aries.apache.org/modules/jmx.html)
+, setup the following dependencies:
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-karaf-remote</artifactId>
+        </dependency>
+    </dependencies>
+
+
+For remote containers the arquillian.xml resource describes the JMX connection details:
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+		<container qualifier="karaf" default="true">
+			<configuration>
+	            <property name="jmxServiceURL">service:jmx:rmi://127.0.0.1:44444/jndi/rmi://127.0.0.1:1099/karaf-root</property>
+	            <property name="jmxUsername">karaf</property>
+	            <property name="jmxPassword">karaf</property>
+			</configuration>
+		</container>
+	</arquillian>
+
+
+For [Apache Aries JMX](http://aries.apache.org/modules/jmx.html), enable RMI access to the JVM and use the following configuration:
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+		<container qualifier="aries" default="true">
+			<configuration>
+	            <property name="jmxServiceURL">service:jmx:rmi:///jndi/rmi://localhost:1090/jmxrmi</property>
+	            <property name="jmxUsername">username</property>
+	            <property name="jmxPassword">password</property>
+			</configuration>
+		</container>
+	</arquillian>
+
+Managed Container Setup
+-----------------------
+
+Managed containers are started in a separate JVM by the Arquillian OSGi Container.
+
+For an [Apache Karaf](http://karaf.apache.org/) managed container, setup these dependencies:
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-karaf-managed</artifactId>
+        </dependency>
+    </dependencies>
+
+... and specify in the arquillian.xml resource the location of a Karaf installation, and JMX connection details:
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<arquillian xmlns="http://jboss.org/schema/arquillian"
+	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+	    <container qualifier="jboss" default="true">
+	        <configuration>
+	            <property name="autostartBundle">false</property>
+	            <property name="karafHome">target/apache-karaf-${version.apache.karaf}</property>
+	            <property name="javaVmArguments">-agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=n</property>
+	            <property name="jmxServiceURL">service:jmx:rmi://127.0.0.1:44444/jndi/rmi://127.0.0.1:1099/karaf-root</property>
+	            <property name="jmxUsername">karaf</property>
+	            <property name="jmxPassword">karaf</property>
+	        </configuration>
+	    </container>
+	</arquillian>
+
+
 Arquillian OSGi Tests
 ---------------------
 

--- a/container/common/src/main/java/org/jboss/arquillian/container/osgi/jmx/JMXDeployableContainer.java
+++ b/container/common/src/main/java/org/jboss/arquillian/container/osgi/jmx/JMXDeployableContainer.java
@@ -18,6 +18,8 @@ package org.jboss.arquillian.container.osgi.jmx;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +45,7 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
 import org.jboss.arquillian.container.osgi.CommonDeployableContainer;
+import org.jboss.arquillian.container.osgi.jmx.http.SimpleHTTPServer;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
@@ -167,9 +170,7 @@ public abstract class JMXDeployableContainer<T extends JMXContainerConfiguration
 
         URL fileURL = resolved[0].toURI().toURL();
 
-        long bundleId = frameworkMBean.installBundleFromURL(filespec, fileURL.toExternalForm());
-        String symbolicName = bundleStateMBean.getSymbolicName(bundleId);
-        BundleHandle handle = new BundleHandle(bundleId, symbolicName);
+        BundleHandle handle = installBundle(filespec, fileURL);
 
         if (startBundle) {
             frameworkMBean.startBundle(handle.getBundleId());
@@ -193,9 +194,43 @@ public abstract class JMXDeployableContainer<T extends JMXContainerConfiguration
     }
 
     private BundleHandle installBundle(String location, URL streamURL) throws BundleException, IOException {
-        long bundleId = frameworkMBean.installBundleFromURL(location, streamURL.toExternalForm());
-        String symbolicName = bundleStateMBean.getSymbolicName(bundleId);
-        return new BundleHandle(bundleId, symbolicName);
+        URL serverUrl = streamURL;
+
+        // Adapt URL to remote system by serving over HTTP
+        SimpleHTTPServer server = null;
+        if (!isLocalHost(config)) {
+            server = new SimpleHTTPServer();
+            serverUrl = server.serve(streamURL);
+            server.start();
+        }
+
+        try {
+            long bundleId = frameworkMBean.installBundleFromURL(location, serverUrl.toExternalForm());
+            String symbolicName = bundleStateMBean.getSymbolicName(bundleId);
+            return new BundleHandle(bundleId, symbolicName);
+        } finally {
+            if (server != null) {
+                server.shutdown();
+            }
+        }
+    }
+
+    private static boolean isLocalHost(JMXContainerConfiguration config) {
+        try {
+            JMXServiceURL serviceURL = new JMXServiceURL(config.getJmxServiceURL());
+            InetAddress addr = InetAddress.getByName(serviceURL.getHost());
+
+            // Any localhost address
+            if (addr.isAnyLocalAddress() || addr.isLoopbackAddress()) {
+                return true;
+            }
+
+            // Address of a local network interface
+            return (NetworkInterface.getByInetAddress(addr) != null);
+        } catch (IOException e) {
+            // Assume name lookups imply not local
+            return false;
+        }
     }
 
     protected String getArquillianBundleVersion() {

--- a/container/common/src/main/java/org/jboss/arquillian/container/osgi/jmx/http/SimpleHTTPServer.java
+++ b/container/common/src/main/java/org/jboss/arquillian/container/osgi/jmx/http/SimpleHTTPServer.java
@@ -1,0 +1,211 @@
+package org.jboss.arquillian.container.osgi.jmx.http;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.jboss.osgi.vfs.VFSUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A very simple HTTP server, capable of serving multiple files.
+ */
+public class SimpleHTTPServer {
+
+    static final Logger _logger = LoggerFactory.getLogger(SimpleHTTPServer.class.getPackage().getName());
+
+    private final Map<String, URL> streams = Collections.synchronizedMap(new HashMap<String, URL>());
+    private final List<ClientConnection> clients = new ArrayList<ClientConnection>();
+    private final ServerSocket serverSocket;
+    private final String canonicalHostName;
+
+    private volatile boolean running = true;
+
+    /**
+     * Constructs an HTTP server, which will run on a randomly selected port on the wildcard address.
+     */
+    public SimpleHTTPServer() throws IOException {
+        this(null, InetAddress.getLocalHost().getCanonicalHostName(), 0);
+    }
+
+    /**
+     * Constructs an HTTP server running on a specified address/port.
+     *
+     * @param bindAddress the address to bind to.
+     * @param port the port to bind to.
+     */
+    public SimpleHTTPServer(InetAddress bindAddress, int port) throws IOException {
+        this(bindAddress, bindAddress.getCanonicalHostName(), port);
+    }
+
+    private SimpleHTTPServer(InetAddress bindAddress, String canonicalHostname, int port) throws IOException {
+        this.canonicalHostName = canonicalHostname;
+        this.serverSocket = new ServerSocket();
+        serverSocket.bind(new InetSocketAddress(bindAddress, port));
+    }
+
+    /**
+     * Register a stream for serving.
+     *
+     * @param stream the URL to obtain the stream contents, which will be opened each time the stream is served.
+     * @return an HTTP URL that can be used to access the contents of the provided stream.
+     */
+    public URL serve(URL stream) {
+        final String token = UUID.randomUUID().toString();
+        streams.put(token, stream);
+        try {
+            return new URL(String.format("http://%s:%d/%s", canonicalHostName, this.serverSocket.getLocalPort(), token));
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException("HTTP url could not be parsed.", e);
+        }
+    }
+
+    private void serve() {
+        try {
+            while (running) {
+                ClientConnection client = new ClientConnection(serverSocket.accept());
+                onClientConnect(client);
+                client.start();
+            }
+        } catch (Exception e) {
+            runError("Error accepting connection", e);
+        }
+    }
+
+    private synchronized void onClientConnect(ClientConnection client) {
+        if (!running) {
+            client.shutdown();
+        } else {
+            clients.add(client);
+        }
+    }
+
+    private synchronized void onClientDisconnect(ClientConnection client) {
+        clients.remove(client);
+    }
+
+    private void runError(String message, Throwable t) {
+        if (running) {
+            _logger.error(message, t);
+        }
+    }
+
+    /**
+     * Starts listening for client connections.
+     */
+    public void start() {
+        Thread srv = new Thread("Simple HTTP Server") {
+            @Override
+            public void run() {
+                serve();
+            }
+        };
+        srv.setDaemon(true);
+        srv.start();
+    }
+
+    /**
+     * Closes this server, closing the server socket and all in-progress client connections.
+     */
+    public void shutdown() {
+        running = false;
+        try {
+            serverSocket.close();
+        } catch (IOException e) {
+        }
+
+        final ArrayList<ClientConnection> runningClients;
+        synchronized (this) {
+            runningClients = new ArrayList<ClientConnection>(clients);
+            clients.clear();
+        }
+        for (ClientConnection client : runningClients) {
+            client.shutdown();
+        }
+    }
+
+    private class ClientConnection extends Thread {
+        private Socket socket;
+
+        public ClientConnection(Socket socket) {
+            setDaemon(true);
+            this.socket = socket;
+        }
+
+        public void run() {
+            try {
+                final BufferedReader input = new BufferedReader(
+                        new InputStreamReader(socket.getInputStream(), "US-ASCII"));
+                final DataOutputStream output = new DataOutputStream(socket.getOutputStream());
+                try {
+                    final String line = input.readLine();
+                    _logger.debug("Incoming request [{}]", line);
+                    if ((line == null) || line.length() < 1) {
+                        return;
+                    }
+                    final URL streamUrl = getRequestedFile(line);
+                    if (streamUrl != null) {
+                        _logger.debug("For [{}] serving {}", line, streamUrl);
+                        writeResponse(output, "200 OK");
+                        VFSUtils.copyStream(streamUrl.openStream(), output);
+                    } else {
+                        writeResponse(output, "404 Not Found");
+                        _logger.warn("For [{}] no file found", line);
+                    }
+                } catch (Exception e) {
+                    writeResponse(output, "500 Server Error");
+                    runError("Error serving file", e);
+                } finally {
+                    output.flush();
+                }
+            } catch (Exception e) {
+                runError("Error setting up file serving thread", e);
+            } finally {
+                shutdown();
+            }
+        }
+
+        private void writeResponse(DataOutputStream output, String responseLine) throws IOException {
+            output.writeBytes("HTTP/1.0 ");
+            output.writeBytes(responseLine);
+            output.writeBytes("\r\n\r\n");
+        }
+
+        private URL getRequestedFile(String requestLine) {
+            if (requestLine.startsWith("GET")) {
+                String[] parts = requestLine.split(" ");
+                if ((parts.length >= 2) && parts[1].startsWith("/")) {
+                    String token = parts[1].substring(1);
+                    return streams.get(token);
+                }
+            }
+            return null;
+        }
+
+        public synchronized void shutdown() {
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                }
+                socket = null;
+            }
+            onClientDisconnect(this);
+        }
+    }
+
+}

--- a/container/karaf/remote/src/main/java/org/jboss/arquillian/container/osgi/karaf/remote/KarafRemoteDeployableContainer.java
+++ b/container/karaf/remote/src/main/java/org/jboss/arquillian/container/osgi/karaf/remote/KarafRemoteDeployableContainer.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeoutException;
  * Remote deployable container for Karaf.
  * <p>
  * Should also work with any remote container with an OSGi Enterprise JMX MBeans implementation
- * (such as Apache Aries JMX) enabled. 
+ * (such as Apache Aries JMX) enabled.
  *
  * @author thomas.diesler@jboss.com
  * @author sbunciak@redhat.com

--- a/container/karaf/remote/src/main/java/org/jboss/arquillian/container/osgi/karaf/remote/KarafRemoteDeployableContainer.java
+++ b/container/karaf/remote/src/main/java/org/jboss/arquillian/container/osgi/karaf/remote/KarafRemoteDeployableContainer.java
@@ -71,7 +71,7 @@ public class KarafRemoteDeployableContainer<T extends KarafRemoteContainerConfig
             mbeanServer = getMBeanServerConnection(30, TimeUnit.SECONDS);
             mbeanServerInstance.set(mbeanServer);
         } catch (TimeoutException e) {
-            logger.error("Error connecting to Karaf MBeanServer: ", e);
+            throw new LifecycleException("Error connecting to Karaf MBeanServer: ", e);
         }
 
         try {

--- a/container/karaf/remote/src/main/java/org/jboss/arquillian/container/osgi/karaf/remote/KarafRemoteDeployableContainer.java
+++ b/container/karaf/remote/src/main/java/org/jboss/arquillian/container/osgi/karaf/remote/KarafRemoteDeployableContainer.java
@@ -32,7 +32,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * KarafRemoteDeployableContainer
+ * Remote deployable container for Karaf.
+ * <p>
+ * Should also work with any remote container with an OSGi Enterprise JMX MBeans implementation
+ * (such as Apache Aries JMX) enabled. 
  *
  * @author thomas.diesler@jboss.com
  * @author sbunciak@redhat.com


### PR DESCRIPTION
Remote container support is currently limited to separate JVMs with a shared filesystem.

This change allows containers on remote hosts to be supported by serving bundles to be installed in the container using a simple (single class) HTTP server. We've been using this approach in our Arquillian fork since 2012 and it's worked well.

Also updated docs to include current set of containers, and to note that the Apache Karaf remote container actually works with any OSGi Enterprise JMX enabled container (we use Apache Aries JMX in an Equinox container).
