### PR TITLE
Updated Felix framework version to 5.4.0, and Karaf version to 4.0.4.

### DIFF
--- a/container/karaf/managed/pom.xml
+++ b/container/karaf/managed/pom.xml
@@ -2,7 +2,8 @@
 <!-- 
     Set these VM properties in your IDE debugger
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <!-- Parent -->
@@ -17,10 +18,10 @@
 
     <!-- Properties -->
     <properties>
-        <karaf.felix.version>4.0.3</karaf.felix.version>
+        <karaf.felix.version>5.4.0</karaf.felix.version>
         <karaf.home>${project.build.directory}/apache-karaf-${version.apache.karaf}</karaf.home>
     </properties>
-    
+
     <!-- Dependencies -->
     <dependencies>
         <dependency>
@@ -50,7 +51,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        
+
         <!-- Provided Dependencies -->
         <dependency>
             <groupId>org.osgi</groupId>
@@ -62,7 +63,7 @@
             <artifactId>org.osgi.enterprise</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
@@ -89,19 +90,21 @@
         </dependency>
     </dependencies>
 
-	<build>
+    <build>
         <testResources>
             <testResource>
                 <directory>src/test/resources</directory>
                 <filtering>true</filtering>
             </testResource>
         </testResources>
-		<plugins>
+        <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
                 <executions>
                     <execution>
-                        <id>unpack-karaf</id>
+                        <id>unpack</id>
                         <phase>process-test-resources</phase>
                         <goals>
                             <goal>unpack</goal>
@@ -112,7 +115,6 @@
                                     <groupId>org.apache.karaf</groupId>
                                     <artifactId>apache-karaf</artifactId>
                                     <version>${version.apache.karaf}</version>
-                                    <classifier>minimal</classifier>
                                     <type>tar.gz</type>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                 </artifactItem>
@@ -132,7 +134,7 @@
                         <configuration>
                             <target>
                                 <echo file="${karaf.home}/etc/custom.properties" append="true">
-# Clean the persitent bundle store on Framework INIT                                
+# Clean the persitent bundle store on Framework INIT
 org.osgi.framework.storage.clean=onFirstInit
                                 </echo>
                             </target>
@@ -146,13 +148,14 @@ org.osgi.framework.storage.clean=onFirstInit
                     <argLine>${surefire.system.args}</argLine>
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
                     <systemPropertyVariables>
-                        <log4j.configuration>file://${basedir}/src/test/resources/logging.properties</log4j.configuration>
+                        <log4j.configuration>file://${basedir}/src/test/resources/logging.properties
+                        </log4j.configuration>
                     </systemPropertyVariables>
                     <dependenciesToScan>
                         <dependency>org.jboss.arquillian.container:arquillian-container-osgi-tests</dependency>
                     </dependenciesToScan>
                 </configuration>
             </plugin>
-		</plugins>
-	</build>
+        </plugins>
+    </build>
 </project>

--- a/container/karaf/managed/src/main/java/org/jboss/arquillian/container/osgi/karaf/managed/KarafManagedDeployableContainer.java
+++ b/container/karaf/managed/src/main/java/org/jboss/arquillian/container/osgi/karaf/managed/KarafManagedDeployableContainer.java
@@ -117,19 +117,20 @@ public class KarafManagedDeployableContainer<T extends KarafManagedContainerConf
             cmd.add("-Djava.io.tmpdir=" + new File(karafHomeDir, "data/tmp"));
             cmd.add("-Djava.util.logging.config.file=" + new File(karafHomeDir, "etc/java.util.logging.properties"));
             cmd.add("-Djava.endorsed.dirs=" + new File(karafHomeDir, "lib/endorsed"));
+            cmd.add("-Djava.ext.dirs=" + new File(karafHomeDir, "lib/ext"));
 
             // Classpath
             StringBuilder classPath = new StringBuilder();
-            File karafLibDir = new File(karafHomeDir, "lib");
+            File karafLibDir = new File(karafHomeDir, "lib/boot");
             String[] libs = karafLibDir.list(new FilenameFilter() {
                 @Override
                 public boolean accept(File dir, String name) {
-                    return name.startsWith("karaf");
+                    return name.endsWith(".jar");
                 }
             });
             for (String lib : libs) {
                 String separator = classPath.length() > 0 ? File.pathSeparator : "";
-                classPath.append(separator).append(new File(karafHomeDir, "lib/" + lib));
+                classPath.append(separator).append(new File(karafHomeDir, "lib/boot/" + lib));
             }
             cmd.add("-classpath");
             cmd.add(classPath.toString());

--- a/container/karaf/remote/pom.xml
+++ b/container/karaf/remote/pom.xml
@@ -97,10 +97,12 @@
 		</testResources>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.10</version>
 				<executions>
 					<execution>
-						<id>unpack-karaf</id>
+						<id>unpack</id>
 						<phase>process-test-resources</phase>
 						<goals>
 							<goal>unpack</goal>
@@ -111,7 +113,6 @@
 									<groupId>org.apache.karaf</groupId>
 									<artifactId>apache-karaf</artifactId>
 									<version>${version.apache.karaf}</version>
-									<classifier>minimal</classifier>
 									<type>tar.gz</type>
 									<outputDirectory>${project.build.directory}</outputDirectory>
 								</artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
 
     <!-- Properties -->
     <properties>
-        <version.apache.felix.framework>4.2.1</version.apache.felix.framework>
-        <version.apache.karaf>2.3.3</version.apache.karaf>
+        <version.apache.felix.framework>5.4.0</version.apache.felix.framework>
+        <version.apache.karaf>4.0.4</version.apache.karaf>
         <version.jboss.arquillian.core>1.1.10.Final</version.jboss.arquillian.core>
         <version.jboss.logging>3.1.3.GA</version.jboss.logging>
         <version.jboss.logmanager>1.4.1.Final</version.jboss.logmanager>


### PR DESCRIPTION
The former version of Karaf was 2.x, which is nearly prehistoric.  This wasn't useful for me, since I use Karaf 4.x.  I made a small change to the portion of code that builds the classpath, since the lib directory changed since version 3.x.  The container starts and the tests run.  However, there are, at times, intermittent test failures on my Mac when the tests that install bad bundles are run for the various containers because the null pointer exception is not checked.  I am only specifying this because it is not a condition that I have created with my modifications, since it happens in modules that I did not update.