### PR TITLE
ARQ-2019 Upgraded to Karaf 4.0.4.

### DIFF
--- a/container/karaf/managed/pom.xml
+++ b/container/karaf/managed/pom.xml
@@ -18,7 +18,7 @@
     <!-- Properties -->
     <properties>
         <karaf.felix.version>4.0.3</karaf.felix.version>
-        <karaf.home>${project.build.directory}/apache-karaf-${version.apache.karaf}</karaf.home>
+        <karaf.home>${project.build.directory}/apache-karaf-minimal-${version.apache.karaf}</karaf.home>
     </properties>
     
     <!-- Dependencies -->
@@ -99,6 +99,7 @@
 		<plugins>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
                 <executions>
                     <execution>
                         <id>unpack-karaf</id>
@@ -110,9 +111,8 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.apache.karaf</groupId>
-                                    <artifactId>apache-karaf</artifactId>
+                                    <artifactId>apache-karaf-minimal</artifactId>
                                     <version>${version.apache.karaf}</version>
-                                    <classifier>minimal</classifier>
                                     <type>tar.gz</type>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                 </artifactItem>
@@ -132,7 +132,7 @@
                         <configuration>
                             <target>
                                 <echo file="${karaf.home}/etc/custom.properties" append="true">
-# Clean the persitent bundle store on Framework INIT                                
+# Clean the persistent bundle store on Framework INIT
 org.osgi.framework.storage.clean=onFirstInit
                                 </echo>
                             </target>

--- a/container/karaf/managed/src/main/java/org/jboss/arquillian/container/osgi/karaf/managed/KarafManagedDeployableContainer.java
+++ b/container/karaf/managed/src/main/java/org/jboss/arquillian/container/osgi/karaf/managed/KarafManagedDeployableContainer.java
@@ -110,6 +110,7 @@ public class KarafManagedDeployableContainer<T extends KarafManagedContainerConf
             cmd.add("-Dkaraf.etc=" + karafHomeDir + "/etc");
             cmd.add("-Dkaraf.data=" + karafHomeDir + "/data");
             cmd.add("-Dkaraf.instances=" + karafHomeDir + "/instances");
+            cmd.add("-Dkaraf.restart.jvm.supported=true");
             cmd.add("-Dkaraf.startLocalConsole=false");
             cmd.add("-Dkaraf.startRemoteShell=false");
 
@@ -120,16 +121,16 @@ public class KarafManagedDeployableContainer<T extends KarafManagedContainerConf
 
             // Classpath
             StringBuilder classPath = new StringBuilder();
-            File karafLibDir = new File(karafHomeDir, "lib");
-            String[] libs = karafLibDir.list(new FilenameFilter() {
+            File karafLibBootDir = new File(karafHomeDir, "lib/boot/");
+            String[] libs = karafLibBootDir.list(new FilenameFilter() {
                 @Override
                 public boolean accept(File dir, String name) {
-                    return name.startsWith("karaf");
+                    return name.endsWith(".jar");
                 }
             });
             for (String lib : libs) {
                 String separator = classPath.length() > 0 ? File.pathSeparator : "";
-                classPath.append(separator).append(new File(karafHomeDir, "lib/" + lib));
+                classPath.append(separator).append(new File(karafLibBootDir, lib));
             }
             cmd.add("-classpath");
             cmd.add(classPath.toString());

--- a/container/karaf/managed/src/test/resources/arquillian.xml
+++ b/container/karaf/managed/src/test/resources/arquillian.xml
@@ -6,7 +6,7 @@
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="autostartBundle">false</property>
-            <property name="karafHome">target/apache-karaf-${version.apache.karaf}</property>
+            <property name="karafHome">${karaf.home}</property>
             <property name="javaVmArguments">-agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=n</property>
             <property name="jmxServiceURL">service:jmx:rmi://127.0.0.1:44444/jndi/rmi://127.0.0.1:1099/karaf-root</property>
             <property name="jmxUsername">karaf</property>

--- a/container/karaf/remote/pom.xml
+++ b/container/karaf/remote/pom.xml
@@ -14,7 +14,7 @@
 	<name>Arquillian OSGi :: Container :: Karaf :: Remote</name>
 
 	<properties>
-		<karaf.home>${project.build.directory}/apache-karaf-${version.apache.karaf}</karaf.home>
+		<karaf.home>${project.build.directory}/apache-karaf-minimal-${version.apache.karaf}</karaf.home>
 		<karaf.started.indicator.file>${karaf.home}/karaf.started</karaf.started.indicator.file>
 		<karaf.executable.start>${karaf.home}/bin/start</karaf.executable.start>
 		<karaf.executable.stop>${karaf.home}/bin/stop</karaf.executable.stop>
@@ -98,6 +98,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.10</version>
 				<executions>
 					<execution>
 						<id>unpack-karaf</id>
@@ -109,9 +110,8 @@
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.apache.karaf</groupId>
-									<artifactId>apache-karaf</artifactId>
+									<artifactId>apache-karaf-minimal</artifactId>
 									<version>${version.apache.karaf}</version>
-									<classifier>minimal</classifier>
 									<type>tar.gz</type>
 									<outputDirectory>${project.build.directory}</outputDirectory>
 								</artifactItem>
@@ -132,9 +132,8 @@
 						<configuration>
 							<target>
 								<echo file="${karaf.home}/etc/custom.properties" append="true">
-									#
-									Clean the persitent bundle store on Framework INIT
-									org.osgi.framework.storage.clean=onFirstInit
+# Clean the persistent bundle store on Framework INIT
+org.osgi.framework.storage.clean=onFirstInit
 								</echo>
 							</target>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <!-- Properties -->
     <properties>
         <version.apache.felix.framework>4.2.1</version.apache.felix.framework>
-        <version.apache.karaf>2.3.3</version.apache.karaf>
+        <version.apache.karaf>4.0.4</version.apache.karaf>
         <version.jboss.arquillian.core>1.1.10.Final</version.jboss.arquillian.core>
         <version.jboss.logging>3.1.3.GA</version.jboss.logging>
         <version.jboss.logmanager>1.4.1.Final</version.jboss.logmanager>


### PR DESCRIPTION
Upgraded Karaf to 4.0.4, and updated the execution environment in accordance with the Karaf startup script.  Tests pass after change.