### PR TITLE
KarafManagedDeployableContainer load boot jar from lib directory if l…

### DIFF
--- a/container/karaf/managed/src/main/java/org/jboss/arquillian/container/osgi/karaf/managed/KarafManagedDeployableContainer.java
+++ b/container/karaf/managed/src/main/java/org/jboss/arquillian/container/osgi/karaf/managed/KarafManagedDeployableContainer.java
@@ -122,6 +122,10 @@ public class KarafManagedDeployableContainer<T extends KarafManagedContainerConf
             // Classpath
             StringBuilder classPath = new StringBuilder();
             File karafLibBootDir = new File(karafHomeDir, "lib/boot/");
+            if (!karafLibBootDir.exists()) {
+                // In Karaf 3 the lib directory contains the boot jars
+                karafLibBootDir = new File(karafHomeDir, "lib/");
+            }
             String[] libs = karafLibBootDir.list(new FilenameFilter() {
                 @Override
                 public boolean accept(File dir, String name) {


### PR DESCRIPTION
#### Short description of what this resolves:

Makes it possible to manage a Karaf 3 container.


#### Changes proposed in this pull request:

KarafManagedDeployableContainer loads the bootstrap jars from ${karaf.home}/lib directory
if ${karaf.home}/lib/boot does not exist


