### PR TITLE
Fix deployment strategy

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -68,17 +68,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.12</version>
+            <version>${version.slf4j}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.osgi.vfs</groupId>
             <artifactId>jbosgi-vfs</artifactId>
-            <version>2.0.0.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.osgi.vfs</groupId>
-            <artifactId>jbosgi-vfs</artifactId>
-            <version>2.0.0.Final</version>
+            <version>${version.jboss.osgi.vfs}</version>
         </dependency>
     </dependencies>
     

--- a/bundle/src/main/java/org/jboss/arquillian/osgi/ArquillianBundleActivator.java
+++ b/bundle/src/main/java/org/jboss/arquillian/osgi/ArquillianBundleActivator.java
@@ -25,13 +25,13 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.osgi.bundle.ArquillianFragmentGenerator;
 import org.jboss.arquillian.protocol.jmx.JMXTestRunner;
 import org.jboss.arquillian.protocol.jmx.JMXTestRunner.TestClassLoader;
 import org.jboss.arquillian.testenricher.osgi.BundleAssociation;
@@ -39,10 +39,8 @@ import org.jboss.arquillian.testenricher.osgi.BundleContextAssociation;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.namespace.HostNamespace;
-import org.osgi.framework.wiring.BundleWire;
-import org.osgi.framework.wiring.BundleWiring;
-import org.osgi.framework.wiring.FrameworkWiring;
+import org.osgi.framework.BundleReference;
+import org.osgi.framework.Constants;
 
 /**
  * This is the Arquillian {@link BundleActivator}.
@@ -57,39 +55,69 @@ public class ArquillianBundleActivator implements BundleActivator {
     private static Logger log = Logger.getLogger(ArquillianBundleActivator.class.getName());
 
     private JMXTestRunner testRunner;
+    private long arqBundleId;
 
     public void start(final BundleContext context) throws Exception {
+
+        arqBundleId = context.getBundle().getBundleId();
 
         final BundleContext syscontext = context.getBundle(0).getBundleContext();
         final TestClassLoader testClassLoader = new TestClassLoader() {
 
             @Override
             public Class<?> loadTestClass(String className) throws ClassNotFoundException {
+                String namePath = className.replace('.', '/') + ".class";
+
+                // Get all installed bundles and remove some
+                List<Bundle> bundles = new ArrayList<Bundle>(Arrays.asList(syscontext.getBundles()));
+                Iterator<Bundle> iterator = bundles.iterator();
+                while(iterator.hasNext()) {
+                    Bundle aux = iterator.next();
+                    if(aux.getBundleId() <= arqBundleId || aux.getState() == Bundle.UNINSTALLED) {
+                        iterator.remove();
+                    }
+                }
+
                 // Load the the test class from the bundle that contains the entry
-                return context.getBundle().loadClass(className);
+                for(Bundle aux : bundles) {
+                    if(aux.getEntry(namePath) != null) {
+                        return aux.loadClass(className);
+                    }
+                }
+
+                // Load the the test class from bundle that defines a Bundle-ClassPath
+                for(Bundle aux : bundles) {
+                    String bundlecp = aux.getHeaders().get(Constants.BUNDLE_CLASSPATH);
+                    if(bundlecp != null) {
+                        try {
+                            return aux.loadClass(className);
+                        } catch(ClassNotFoundException ex) {
+                            // ignore
+                        }
+                    }
+                }
+
+                throw new ClassNotFoundException("Test '" + className + "' not found in: " + bundles);
             }
         };
 
         // Register the JMXTestRunner
         MBeanServer mbeanServer = findOrCreateMBeanServer();
         testRunner = new JMXTestRunner(testClassLoader) {
+
             @Override
             public byte[] runTestMethod(String className, String methodName) {
                 Thread thread = Thread.currentThread();
-
                 ClassLoader contextClassLoader = thread.getContextClassLoader();
-
                 try {
-                    Bundle bundle = context.getBundle();
-
-                    thread.setContextClassLoader(
-                        bundle.adapt(BundleWiring.class).getClassLoader());
-
+                    thread.setContextClassLoader(testClassLoader.loadTestClass(className).getClassLoader());
                     return super.runTestMethod(className, methodName);
-                }
-                finally {
+                } catch(ClassNotFoundException e) {
+                    log.warning("Can't find class" + className);
+                } finally {
                     thread.setContextClassLoader(contextClassLoader);
                 }
+                return null;
             }
 
             @Override
@@ -100,15 +128,7 @@ public class ArquillianBundleActivator implements BundleActivator {
                 } catch (ClassNotFoundException ex) {
                     throw new IllegalStateException(ex);
                 }
-                Bundle fragmentBundle = getFragmentBundle(context);
-
-                Bundle testBundle = getTestBundle(syscontext, fragmentBundle.getHeaders().get(ArquillianFragmentGenerator.TEST_BUNDLE_SYMBOLIC_NAME), testClass, methodName);
-
-                FrameworkWiring adapt = syscontext.getBundle().adapt(FrameworkWiring.class);
-
-                adapt.resolveBundles(Arrays.asList(testBundle));
-
-                BundleAssociation.setBundle(testBundle);
+                BundleAssociation.setBundle(getTestBundle(syscontext, testClass, methodName));
                 BundleContextAssociation.setBundleContext(syscontext);
                 return super.runTestMethod(className, methodName, protocolProps);
             }
@@ -142,54 +162,19 @@ public class ArquillianBundleActivator implements BundleActivator {
         return mbeanServer;
     }
 
-    private Bundle getFragmentBundle(BundleContext context) {
-        BundleWiring bundleWiring = context.getBundle().adapt(BundleWiring.class );
-
-        List<Bundle> fragmentBundles = new ArrayList<Bundle>();
-
-        if (bundleWiring != null) {
-            List<BundleWire> providedWires = bundleWiring.getProvidedWires(HostNamespace.HOST_NAMESPACE);
-
-            for (BundleWire providedWire : providedWires) {
-                fragmentBundles.add(providedWire.getRequirerWiring().getRevision().getBundle());
-            }
-        }
-
-        if (fragmentBundles.isEmpty()) {
-            throw new RuntimeException("There are not fragment associated with the context");
-        }
-
-        if (fragmentBundles.size() > 1) {
-            throw new RuntimeException("There are more than one fragment for the Arquilian Bundle");
-        }
-
-        return fragmentBundles.get(0);
-
-    }
-
-    private Bundle getTestBundle(BundleContext syscontext, String testBundleSymbolicName, Class<?> testClass, String methodName) {
-        Bundle testBundle = null;
-
-        for (Bundle aux : syscontext.getBundles()) {
-            if (aux.getSymbolicName().equals(testBundleSymbolicName)) {
-                testBundle = aux;
-
-                break;
-            }
-        }
-
-        for (Method method : testClass.getMethods()) {
+    private Bundle getTestBundle(BundleContext syscontext, Class<?> testClass, String methodName) {
+        Bundle bundle = ((BundleReference) testClass.getClassLoader()).getBundle();
+        for(Method method : testClass.getMethods()) {
             OperateOnDeployment opon = method.getAnnotation(OperateOnDeployment.class);
-            if (opon != null && methodName.equals(method.getName())) {
-                for (Bundle aux : syscontext.getBundles()) {
-                    if (aux.getLocation().equals(opon.value())) {
-                        testBundle = aux;
+            if(opon != null && methodName.equals(method.getName())) {
+                for(Bundle aux : syscontext.getBundles()) {
+                    if(aux.getLocation().equals(opon.value())) {
+                        bundle = aux;
                         break;
                     }
                 }
             }
         }
-
-        return testBundle;
+        return bundle;
     }
 }

--- a/bundle/src/main/java/org/jboss/arquillian/osgi/bundle/ArquillianBundleGenerator.java
+++ b/bundle/src/main/java/org/jboss/arquillian/osgi/bundle/ArquillianBundleGenerator.java
@@ -21,6 +21,24 @@
  */
 package org.jboss.arquillian.osgi.bundle;
 
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.osgi.ArquillianBundleActivator;
+import org.jboss.arquillian.protocol.jmx.JMXTestRunner;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import org.osgi.framework.Constants;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -31,23 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
-import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
-import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
-import org.jboss.arquillian.core.api.Instance;
-import org.jboss.arquillian.core.api.annotation.Inject;
-import org.jboss.arquillian.core.spi.ServiceLoader;
-import org.jboss.arquillian.osgi.ArquillianBundleActivator;
-import org.jboss.arquillian.protocol.jmx.JMXTestRunner;
-import org.jboss.osgi.metadata.OSGiManifestBuilder;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ArchivePath;
-import org.jboss.shrinkwrap.api.Filters;
-import org.jboss.shrinkwrap.api.Node;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.osgi.framework.Constants;
 
 /**
  * ArquillianBundleGenerator

--- a/bundle/src/main/java/org/jboss/arquillian/osgi/bundle/ArquillianBundleGenerator.java
+++ b/bundle/src/main/java/org/jboss/arquillian/osgi/bundle/ArquillianBundleGenerator.java
@@ -24,11 +24,13 @@ package org.jboss.arquillian.osgi.bundle;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.core.api.Instance;
@@ -54,6 +56,30 @@ import org.osgi.framework.Constants;
  */
 public class ArquillianBundleGenerator {
 
+    private static final List<String> exportPackages = Arrays.asList(
+            "org.jboss.arquillian.container.test.api",
+            "org.jboss.arquillian.junit",
+            "org.jboss.arquillian.osgi",
+            "org.jboss.arquillian.test.api",
+            "org.jboss.shrinkwrap.api",
+            "org.jboss.shrinkwrap.api.asset",
+            "org.jboss.shrinkwrap.api.spec",
+            "junit.framework",
+            "org.hamcrest",
+            "org.hamcrest.core",
+            "org.junit",
+            "org.junit.matchers",
+            "org.junit.rules",
+            "org.junit.runner",
+            "org.junit.runner.manipulation",
+            "org.junit.runner.notification",
+            "org.junit.runners",
+            "org.junit.runners.model",
+            "org.junit.runners.parameterized",
+            "org.junit.validator",
+            "org.osgi.framework",
+            "org.jboss.osgi.metadata");
+
     public Archive<?> createArquillianBundle()
         throws Exception{
 
@@ -72,10 +98,7 @@ public class ArquillianBundleGenerator {
         properties.setProperty(Constants.BUNDLE_ACTIVATOR, ArquillianBundleActivator.class.getCanonicalName());
         properties.setProperty(Constants.IMPORT_PACKAGE, "*;resolution:=optional");
 
-        String exportPackages ="org.jboss.arquillian.container.test.api,org.jboss.arquillian.junit,org.jboss.arquillian.osgi,org.jboss.arquillian.test.api," +
-                "org.jboss.shrinkwrap.api,org.jboss.shrinkwrap.api.asset,org.jboss.shrinkwrap.api.spec," +
-                "org.junit,org.junit.runner,org.osgi.framework,org.jboss.osgi.metadata";
-        properties.setProperty(Constants.EXPORT_PACKAGE, exportPackages);
+        properties.setProperty(Constants.EXPORT_PACKAGE, exportPackages.stream().collect(Collectors.joining(",")));
 
         List<Archive<?>> extensionArchives = loadAuxiliaryArchives();
 

--- a/bundle/src/main/java/org/jboss/arquillian/osgi/bundle/ArquillianBundleGenerator.java
+++ b/bundle/src/main/java/org/jboss/arquillian/osgi/bundle/ArquillianBundleGenerator.java
@@ -72,7 +72,10 @@ public class ArquillianBundleGenerator {
         properties.setProperty(Constants.BUNDLE_ACTIVATOR, ArquillianBundleActivator.class.getCanonicalName());
         properties.setProperty(Constants.IMPORT_PACKAGE, "*;resolution:=optional");
 
-        properties.setProperty(Constants.EXPORT_PACKAGE, OSGiManifestBuilder.class.getPackage().getName());
+        String exportPackages ="org.jboss.arquillian.container.test.api,org.jboss.arquillian.junit,org.jboss.arquillian.osgi,org.jboss.arquillian.test.api," +
+                "org.jboss.shrinkwrap.api,org.jboss.shrinkwrap.api.asset,org.jboss.shrinkwrap.api.spec," +
+                "org.junit,org.junit.runner,org.osgi.framework,org.jboss.osgi.metadata";
+        properties.setProperty(Constants.EXPORT_PACKAGE, exportPackages);
 
         List<Archive<?>> extensionArchives = loadAuxiliaryArchives();
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -37,9 +37,6 @@
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>
-        <module name="RedundantThrows">
-            <property name="allowUnchecked" value="true"/>
-        </module>
 
         <!-- Miscellaneous other checks.                   -->
         <module name="UpperEll"/>

--- a/container/common/src/main/java/org/jboss/arquillian/container/osgi/CommonDeployableContainer.java
+++ b/container/common/src/main/java/org/jboss/arquillian/container/osgi/CommonDeployableContainer.java
@@ -1,13 +1,21 @@
 package org.jboss.arquillian.container.osgi;
 
-import java.util.List;
-
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.osgi.bundle.ArquillianBundleGenerator;
 import org.jboss.shrinkwrap.api.Archive;
 
-public abstract class CommonDeployableContainer <T extends CommonContainerConfiguration> implements DeployableContainer<T> {
+import java.util.List;
+
+public abstract class CommonDeployableContainer<T extends CommonContainerConfiguration> implements DeployableContainer<T> {
 
     private CommonContainerConfiguration config;
+    private Long arquillianBundleId;
+
+    @Inject
+    private Instance<ServiceLoader> _serviceLoaderInstance;
 
     /**
      * @return Returns true if container starts bundles after deployment automaticly otherwise returns false
@@ -18,6 +26,7 @@ public abstract class CommonDeployableContainer <T extends CommonContainerConfig
 
     /**
      * Install a bundle from an Archive
+     *
      * @param archive Archive
      * @return Returns the bundleId of the bundle that has been just installed
      * @throws Exception If an error occured and therefore bundle was not installed
@@ -26,20 +35,23 @@ public abstract class CommonDeployableContainer <T extends CommonContainerConfig
 
     /**
      * Perform a "refresh packages" operation
+     *
      * @throws Exception If an error occured
      */
     public abstract void refresh() throws Exception;
 
     /**
      * Start a bundle identified by <code>symbolicName</code> and <code>version</code>
+     *
      * @param symbolicName Bundle symbolic name
-     * @param version Bundle version
+     * @param version      Bundle version
      * @throws Exception If an error occured and therefore bundle was not started
      */
     public abstract void startBundle(String symbolicName, String version) throws Exception;
 
     /**
      * Uninstall a bundle identified by <code>bundleId</code>
+     *
      * @param bundleId Bundle id
      * @throws Exception If an error occured and therefore bundle was not uninstalled
      */
@@ -59,10 +71,28 @@ public abstract class CommonDeployableContainer <T extends CommonContainerConfig
 
     /**
      * Await for bootstrap service
+     *
      * @param name
      * @throws IllegalStateException If bootstrap service was not started
      */
     protected abstract void awaitBootstrapCompleteService(String name);
+
+    protected long installArquillianBundle() throws Exception {
+        ServiceLoader serviceLoader = _serviceLoaderInstance.get();
+        ArquillianBundleGenerator arquillianBundleGenerator = serviceLoader.onlyOne(ArquillianBundleGenerator.class);
+
+        Archive arquillianBundle = arquillianBundleGenerator.createArquillianBundle();
+        arquillianBundleId = installBundle(arquillianBundle, true);
+        return arquillianBundleId;
+    }
+
+    protected void uninstallArquillianBundle() throws Exception {
+        if(arquillianBundleId == null)
+        {
+            throw new IllegalStateException("Arquillian bundle is not installed");
+        }
+        uninstallBundle(arquillianBundleId);
+    }
 
     @Override
     public void setup(T configuration) {

--- a/container/common/src/main/java/org/jboss/arquillian/container/osgi/DeploymentObserver.java
+++ b/container/common/src/main/java/org/jboss/arquillian/container/osgi/DeploymentObserver.java
@@ -42,33 +42,6 @@ public class DeploymentObserver {
 
     static final Logger logger = LoggerFactory.getLogger(DeploymentObserver.class.getPackage().getName());
 
-    public void buildArquillianOSGiBundle(@Observes BeforeSetup event) throws Exception {
-        if (_arquillianOSGiBundle == null) {
-            ServiceLoader serviceLoader = _serviceLoaderInstance.get();
-
-            ArquillianBundleGenerator arquillianBundleGenerator =
-                serviceLoader.onlyOne(ArquillianBundleGenerator.class);
-
-            _arquillianOSGiBundle = arquillianBundleGenerator.createArquillianBundle();
-        }
-    }
-
-    public void startContainer(@Observes AfterStart event) throws Exception {
-        if (event.getDeployableContainer() instanceof CommonDeployableContainer) {
-            container = (CommonDeployableContainer<?>) event.getDeployableContainer();
-        }
-    }
-
-    public void installArquillianBundle(@Observes Before event) throws Exception {
-        _arquillianOSGiBundleId = container.installBundle(_arquillianOSGiBundle, true);
-    }
-
-    public void uninstallArquillianBundle(@Observes After event) throws Exception {
-        container.uninstallBundle(_arquillianOSGiBundleId);
-
-        container.refresh();
-    }
-
     public void autostartBundle(@Observes AfterDeploy event) throws Exception {
         if (event.getDeployableContainer() instanceof CommonDeployableContainer) {
             CommonDeployableContainer<?> container = (CommonDeployableContainer<?>) event.getDeployableContainer();
@@ -83,13 +56,4 @@ public class DeploymentObserver {
             }
         }
     }
-
-    private CommonDeployableContainer<?> container;
-
-    private Archive<?> _arquillianOSGiBundle;
-
-    private long _arquillianOSGiBundleId;
-
-    @Inject
-    private Instance<ServiceLoader> _serviceLoaderInstance;
 }

--- a/container/common/src/main/java/org/jboss/arquillian/container/osgi/jmx/JMXDeployableContainer.java
+++ b/container/common/src/main/java/org/jboss/arquillian/container/osgi/jmx/JMXDeployableContainer.java
@@ -90,10 +90,6 @@ public abstract class JMXDeployableContainer<T extends JMXContainerConfiguration
     protected BundleStateMBean bundleStateMBean;
     protected ServiceStateMBean serviceStateMBean;
 
-
-    @Inject
-    private Instance<ServiceLoader> _serviceLoaderInstance;
-
     protected JMXContainerConfiguration getContainerConfiguration() {
         return config;
     }
@@ -323,18 +319,6 @@ public abstract class JMXDeployableContainer<T extends JMXContainerConfiguration
             }
         }
         throw new TimeoutException("Arquillian bundle [" + bundleId + "] not started: " + bundleState);
-    }
-
-    protected Long installArquillianBundle() {
-        ServiceLoader serviceLoader = _serviceLoaderInstance.get();
-        ArquillianBundleGenerator arquillianBundleGenerator = serviceLoader.onlyOne(ArquillianBundleGenerator.class);
-        try {
-            Archive arquillianBundle = arquillianBundleGenerator.createArquillianBundle();
-            return installBundle(arquillianBundle, true);
-        } catch (Exception e) {
-            logger.error("Can't generate " + ArquillianBundleGenerator.BUNDLE_NAME);
-        }
-        return null;
     }
 
     protected MBeanServerConnection getMBeanServerConnection(final long timeout, final TimeUnit unit)

--- a/container/common/src/main/java/org/jboss/arquillian/container/osgi/jmx/http/SimpleHTTPServer.java
+++ b/container/common/src/main/java/org/jboss/arquillian/container/osgi/jmx/http/SimpleHTTPServer.java
@@ -141,7 +141,7 @@ public class SimpleHTTPServer {
     private class ClientConnection extends Thread {
         private Socket socket;
 
-        public ClientConnection(Socket socket) {
+        ClientConnection(Socket socket) {
             setDaemon(true);
             this.socket = socket;
         }

--- a/container/equinox/embedded/pom.xml
+++ b/container/equinox/embedded/pom.xml
@@ -74,9 +74,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-        	<groupId>org.eclipse.osgi</groupId>
-        	<artifactId>org.eclipse.osgi</artifactId>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
         </dependency>
+
         <!-- Shared tests -->
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>

--- a/container/jbosgi/embedded/pom.xml
+++ b/container/jbosgi/embedded/pom.xml
@@ -44,6 +44,18 @@
             <groupId>org.jboss.osgi.framework</groupId>
             <artifactId>jbosgi-framework-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.msc</groupId>
+            <artifactId>jboss-msc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.modules</groupId>
+            <artifactId>jboss-modules</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-vfs</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/container/karaf/managed/pom.xml
+++ b/container/karaf/managed/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>jbosgi-spi</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-vfs</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.osgi.vfs</groupId>
             <artifactId>jbosgi-vfs30</artifactId>
         </dependency>

--- a/container/karaf/managed/src/main/java/org/jboss/arquillian/container/osgi/karaf/managed/KarafManagedDeployableContainer.java
+++ b/container/karaf/managed/src/main/java/org/jboss/arquillian/container/osgi/karaf/managed/KarafManagedDeployableContainer.java
@@ -32,6 +32,7 @@ import javax.management.ObjectName;
 import org.jboss.arquillian.container.osgi.jmx.JMXDeployableContainer;
 import org.jboss.arquillian.container.osgi.jmx.ObjectNameFactory;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+import org.jboss.arquillian.osgi.bundle.ArquillianBundleGenerator;
 import org.osgi.jmx.framework.BundleStateMBean;
 import org.osgi.jmx.framework.FrameworkMBean;
 import org.osgi.jmx.framework.ServiceStateMBean;
@@ -186,6 +187,9 @@ public class KarafManagedDeployableContainer<T extends KarafManagedContainerConf
 
             // Await bootsrap complete services
             awaitBootstrapCompleteServices();
+
+            long bundleId = installArquillianBundle();
+            awaitBundleActive(bundleId, 30, TimeUnit.SECONDS);
 
         } catch (RuntimeException rte) {
             destroyKarafProcess();

--- a/container/karaf/managed/src/main/java/org/jboss/arquillian/container/osgi/karaf/managed/KarafManagedDeployableContainer.java
+++ b/container/karaf/managed/src/main/java/org/jboss/arquillian/container/osgi/karaf/managed/KarafManagedDeployableContainer.java
@@ -25,10 +25,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
-
 import org.jboss.arquillian.container.osgi.jmx.JMXDeployableContainer;
 import org.jboss.arquillian.container.osgi.jmx.ObjectNameFactory;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
@@ -78,8 +76,8 @@ public class KarafManagedDeployableContainer<T extends KarafManagedContainerConf
         if (mbeanServer != null && !config.isAllowConnectingToRunningServer()) {
             throw new LifecycleException(
                     "The server is already running! Managed containers does not support connecting to running server instances due to the " +
-                    "possible harmful effect of connecting to the wrong server. Please stop server before running or change to another type of container.\n" +
-                    "To disable this check and allow Arquillian to connect to a running server, set allowConnectingToRunningServer to true in the container configuration");
+                            "possible harmful effect of connecting to the wrong server. Please stop server before running or change to another type of container.\n" +
+                            "To disable this check and allow Arquillian to connect to a running server, set allowConnectingToRunningServer to true in the container configuration");
         }
 
         // Start the Karaf process
@@ -187,9 +185,11 @@ public class KarafManagedDeployableContainer<T extends KarafManagedContainerConf
 
             // Await bootsrap complete services
             awaitBootstrapCompleteServices();
-
-            long bundleId = installArquillianBundle();
-            awaitBundleActive(bundleId, 30, TimeUnit.SECONDS);
+            try {
+                installArquillianBundle();
+            } catch (Exception e) {
+                _logger.error("Can't deploy " + ArquillianBundleGenerator.BUNDLE_NAME);
+            }
 
         } catch (RuntimeException rte) {
             destroyKarafProcess();

--- a/container/karaf/remote/pom.xml
+++ b/container/karaf/remote/pom.xml
@@ -42,6 +42,10 @@
 			<artifactId>jbosgi-spi</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.jboss</groupId>
+			<artifactId>jboss-vfs</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.jboss.osgi.vfs</groupId>
 			<artifactId>jbosgi-vfs30</artifactId>
 		</dependency>

--- a/container/karaf/remote/src/main/java/org/jboss/arquillian/container/osgi/karaf/remote/KarafRemoteDeployableContainer.java
+++ b/container/karaf/remote/src/main/java/org/jboss/arquillian/container/osgi/karaf/remote/KarafRemoteDeployableContainer.java
@@ -16,20 +16,18 @@
  */
 package org.jboss.arquillian.container.osgi.karaf.remote;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
 import org.jboss.arquillian.container.osgi.jmx.JMXDeployableContainer;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
-
+import org.jboss.arquillian.osgi.bundle.ArquillianBundleGenerator;
 import org.osgi.jmx.framework.BundleStateMBean;
 import org.osgi.jmx.framework.FrameworkMBean;
 import org.osgi.jmx.framework.ServiceStateMBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.management.MBeanServerConnection;
-import javax.management.ObjectName;
-
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Remote deployable container for Karaf.
@@ -93,8 +91,11 @@ public class KarafRemoteDeployableContainer<T extends KarafRemoteContainerConfig
             // Await bootsrap complete services
             awaitBootstrapCompleteServices();
 
-            long bundleId = installArquillianBundle();
-            awaitBundleActive(bundleId, 30, TimeUnit.SECONDS);
+            try {
+                installArquillianBundle();
+            } catch (Exception e) {
+                logger.error("Can't deploy " + ArquillianBundleGenerator.BUNDLE_NAME);
+            }
 
         } catch (RuntimeException rte) {
             throw rte;
@@ -105,6 +106,11 @@ public class KarafRemoteDeployableContainer<T extends KarafRemoteContainerConfig
 
     @Override
     public void stop() throws LifecycleException {
+        try {
+            uninstallArquillianBundle();
+        } catch (Exception e) {
+            logger.error("Can't uninstall arquillian bundle", e);
+        }
         super.stop();
     }
 }

--- a/container/karaf/remote/src/main/java/org/jboss/arquillian/container/osgi/karaf/remote/KarafRemoteDeployableContainer.java
+++ b/container/karaf/remote/src/main/java/org/jboss/arquillian/container/osgi/karaf/remote/KarafRemoteDeployableContainer.java
@@ -93,6 +93,9 @@ public class KarafRemoteDeployableContainer<T extends KarafRemoteContainerConfig
             // Await bootsrap complete services
             awaitBootstrapCompleteServices();
 
+            long bundleId = installArquillianBundle();
+            awaitBundleActive(bundleId, 30, TimeUnit.SECONDS);
+
         } catch (RuntimeException rte) {
             throw rte;
         } catch (Exception ex) {

--- a/container/tests/src/test/java/org/jboss/test/arquillian/container/complex/ComplexDeploymentParent.java
+++ b/container/tests/src/test/java/org/jboss/test/arquillian/container/complex/ComplexDeploymentParent.java
@@ -1,0 +1,16 @@
+package org.jboss.test.arquillian.container.complex;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+public class ComplexDeploymentParent {
+
+    @Rule
+    public ExpectedException thrown= ExpectedException.none();
+
+
+    protected void inheritanceTest(boolean x) {
+        Assert.assertTrue(x);
+    }
+}

--- a/container/tests/src/test/java/org/jboss/test/arquillian/container/complex/ComplexDeploymentTestCase.java
+++ b/container/tests/src/test/java/org/jboss/test/arquillian/container/complex/ComplexDeploymentTestCase.java
@@ -1,0 +1,51 @@
+package org.jboss.test.arquillian.container.complex;
+
+import java.io.InputStream;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.osgi.metadata.OSGiManifestBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+/**
+ * Complex deployment test case.
+ * Verifies inheritance + usage Junit packages in parent class
+ *
+ * @author jbouska@redhat.com
+ * @since 17-July-2018
+ */
+@RunWith(Arquillian.class)
+public class ComplexDeploymentTestCase extends ComplexDeploymentParent{
+
+    @Deployment
+    public static JavaArchive createdeployment() {
+       final JavaArchive archive= ShrinkWrap.create(JavaArchive.class, "test.jar")
+               .addClass(CustomException.class);
+        archive.setManifest(new Asset() {
+            public InputStream openStream() {
+                OSGiManifestBuilder builder = OSGiManifestBuilder.newInstance();
+                builder.addBundleSymbolicName(archive.getName());
+                builder.addBundleManifestVersion(2);
+                builder.addImportPackage(ExpectedException.class.getPackage().getName());
+                return builder.openStream();
+            }
+        });
+        return archive;
+    }
+
+    @Test
+    public void inheritanceTest(){
+        inheritanceTest(true);
+    }
+
+    @Test
+    public void ruleTest() throws CustomException {
+        thrown.expect(CustomException.class);
+        throw new CustomException("This exception should be catch by Junit rule");
+    }
+}

--- a/container/tests/src/test/java/org/jboss/test/arquillian/container/complex/CustomException.java
+++ b/container/tests/src/test/java/org/jboss/test/arquillian/container/complex/CustomException.java
@@ -1,0 +1,7 @@
+package org.jboss.test.arquillian.container.complex;
+
+public class CustomException extends Exception{
+    public CustomException(String message) {
+        super(message);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <!-- Parent -->
@@ -28,26 +29,31 @@
     <properties>
         <version.apache.felix.framework>4.2.1</version.apache.felix.framework>
         <version.apache.karaf>4.0.4</version.apache.karaf>
-        <version.jboss.arquillian.core>1.1.10.Final</version.jboss.arquillian.core>
-        <version.jboss.logging>3.1.3.GA</version.jboss.logging>
+        <version.jboss.arquillian.core>1.4.0.Final</version.jboss.arquillian.core>
+        <version.jboss.logging>3.3.1.Final</version.jboss.logging>
         <version.jboss.logmanager>1.4.1.Final</version.jboss.logmanager>
-        <version.jboss.osgi.framework>3.0.3.Final</version.jboss.osgi.framework>
+        <version.jboss.osgi.framework>5.0.1.Final</version.jboss.osgi.framework>
         <version.jboss.osgi.metadata>4.0.0.CR1</version.jboss.osgi.metadata>
-        <version.jboss.osgi.spi>4.0.0.Final</version.jboss.osgi.spi>
-        <version.jboss.osgi.vfs>2.0.0.Final</version.jboss.osgi.vfs>
-        <version.jboss.shrinkwrap>1.2.3</version.jboss.shrinkwrap>
-        <version.jboss.shrinkwrap.resolver>2.2.0</version.jboss.shrinkwrap.resolver>
-        <version.junit>4.11</version.junit>
+        <version.jboss.osgi.spi>6.0.1.Final</version.jboss.osgi.spi>
+        <version.jboss.osgi.vfs>4.0.1.Final</version.jboss.osgi.vfs>
+        <version.jboss.vfs>3.2.11.Final</version.jboss.vfs>
+        <version.jboss.modules>1.5.1.Final</version.jboss.modules>
+        <version.jboss.msc>1.2.6.Final</version.jboss.msc>
+        <version.junit>4.12</version.junit>
         <version.hamcrest-core>1.3</version.hamcrest-core>
         <version.mockito>1.8.4</version.mockito>
-        <version.osgi>5.0.0</version.osgi>
+        <version.osgi>6.0.0</version.osgi>
+        <version.osgi.enterprise>5.0.0</version.osgi.enterprise>
         <version.slf4j>1.5.11</version.slf4j>
-		<version.eclipse.equinox>3.7.1</version.eclipse.equinox>
-		
-		<!-- Plugin versions -->
+        <version.eclipse.equinox>3.11.2</version.eclipse.equinox>
+
+        <!-- Plugin versions -->
         <version-maven-antrun-plugin>1.7</version-maven-antrun-plugin>
         <version-maven-javadoc-plugin>2.10.3</version-maven-javadoc-plugin>
-		<version-maven-release-plugin>2.5.3</version-maven-release-plugin>
+        <version-maven-release-plugin>2.5.3</version-maven-release-plugin>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <!-- Modules -->
@@ -120,14 +126,19 @@
                 <version>${version.jboss.osgi.vfs}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.shrinkwrap</groupId>
-                <artifactId>shrinkwrap-impl-base</artifactId>
-                <version>${version.jboss.shrinkwrap}</version>
+                <groupId>org.jboss</groupId>
+                <artifactId>jboss-vfs</artifactId>
+                <version>${version.jboss.vfs}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-depchain</artifactId>
-                <version>${version.jboss.shrinkwrap.resolver}</version>
+                <groupId>org.jboss.msc</groupId>
+                <artifactId>jboss-msc</artifactId>
+                <version>${version.jboss.msc}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.modules</groupId>
+                <artifactId>jboss-modules</artifactId>
+                <version>${version.jboss.modules}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
@@ -142,7 +153,7 @@
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.enterprise</artifactId>
-                <version>${version.osgi}</version>
+                <version>${version.osgi.enterprise}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -164,8 +175,8 @@
                 <artifactId>junit</artifactId>
                 <version>${version.junit}</version>
             </dependency>
-			<dependency>
-                <groupId>org.eclipse.osgi</groupId>
+            <dependency>
+                <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.osgi</artifactId>
                 <version>${version.eclipse.equinox}</version>
             </dependency>
@@ -182,7 +193,7 @@
                     <configLocation>${basedir}/../checkstyle.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
-                    <useFile />
+                    <useFile/>
                 </configuration>
                 <executions>
                     <execution>
@@ -201,6 +212,11 @@
         </plugins>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
@@ -242,7 +258,7 @@
             <url>https://repository.jboss.org/nexus/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
-    
+
     <!-- Repositories -->
     <repositories>
         <repository>
@@ -260,6 +276,6 @@
             </snapshots>
         </repository>
     </repositories>
-    
+
 </project>
 


### PR DESCRIPTION
This Pull request fixes shortcomings which are described in https://github.com/arquillian/arquillian-container-osgi/pull/54#issuecomment-401010899 and can be easily reproduced by running [ComplexDeploymentTestCase](https://github.com/arquillian/arquillian-container-osgi/blob/7f9ac8d3e377cbf0499c9d8c43415bfa8f553fab/container/tests/src/test/java/org/jboss/test/arquillian/container/complex/ComplexDeploymentTestCase.java)

# Description
 https://github.com/arquillian/arquillian-container-osgi/commit/a663171012cc6409744a394f0f1ac5b689151ce4#diff-94377c156735b39dfa4ac607234cb87c splits arquillian deployment into 3 separate bundles:
- **Arquillian bundle** - management package
- **deployment** - contains ONLY classes added by @Deployment method
- **fragment** of Arquillian-bundle - contains test classes

This split totally destroy backward compatibility and breaks all tests which are dependent on some class from **deployment** archive. Moreover Deployments which requires import packages such as `org.junit` can't be deployed.

# What was fixed:
- This PR is based on the "old" deployment approach (before a663171) but it takes benefits from new approach and fixes problems with loading Arquillian extensions.
- Migrate to newest version of Arquillian core.
- Migrate to Java 8 and refactor to benefit from its features.